### PR TITLE
Add a `foreman_options` setting for foreman CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,10 @@ require 'foreman/capistrano'
 # Defaults settings
 set :foreman_sudo, 'sudo' # Set to `rvmsudo` if using RVM
 set :foreman_upstart_path, '/etc/init/sites' # Set /etc/init/ if you do not have a sites folder
-set :foreman_upstart_prefix, '' # Set to ex. `foreman-` or `staging-` if you want to prefix jobs names
 
 # Default foreman options
 set :foreman_options, {
-  :app => '#{foreman_upstart_prefix}#{application}',
+  :app => application,
   :log => "#{shared_path}/log",
   :user => user,
 }

--- a/lib/capistrano/foreman.rb
+++ b/lib/capistrano/foreman.rb
@@ -2,45 +2,43 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
 
   _cset(:foreman_sudo, 'sudo')
   _cset(:foreman_upstart_path, '/etc/init/sites')
-  _cset(:foreman_upstart_prefix, '')
   _cset(:foreman_options, {})
 
   namespace :foreman do
     desc "Export the Procfile to Ubuntu's upstart scripts"
     task :export, roles: :app do
       run "if [[ -d #{foreman_upstart_path} ]]; then #{foreman_sudo} mkdir -p #{foreman_upstart_path}; fi"
-      run "cd #{current_path} && #{foreman_sudo} bundle exec foreman export upstart #{foreman_upstart_path} #{foreman_options_cli}"
+      run "cd #{current_path} && #{foreman_sudo} bundle exec foreman export upstart #{foreman_upstart_path} #{opts(foreman_opts)}"
     end
 
     desc "Start the application services"
     task :start, roles: :app do
-      sudo "service #{service_name} start"
+      sudo "service #{foreman_opts[:app]} start"
     end
 
     desc "Stop the application services"
     task :stop, roles: :app do
-      sudo "service #{service_name} stop"
+      sudo "service #{foreman_opts[:app]} stop"
     end
 
     desc "Restart the application services"
     task :restart, roles: :app do
-      run "sudo service #{service_name} start || sudo service #{service_name}  restart"
+      run "sudo service #{foreman_opts[:app]} start || sudo service #{foreman_opts[:app]}  restart"
     end
   end
 
-  def service_name
-    "#{foreman_upstart_prefix}#{application}"
-  end
-
-  def foreman_options_cli
+  def foreman_opts
     options = {
-      :app => service_name,
+      :app => application,
       :log => "#{shared_path}/log",
       :user => user
     }
-    options.merge!(foreman_options)
-    opt = options.map {|opt, value| "--#{opt}=#{value}" }
-    opt.join(' ')
+    options.merge(foreman_options)
+  end
+
+  def opts(options)
+    opts = options.map {|opt, value| "--#{opt}=#{value}" }
+    opts.join(' ')
   end
   
 end


### PR DESCRIPTION
This allow me to set multiple env files (some generated by Chef recipe, some configured by my application).
