### PR TITLE
Add a capistrano option to use rvmsudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Capistrano tasks for foreman and upstart.
 Add this to your config/deploy.rb:
 
     require "foreman/capistrano"
+    # Optional configuration for RVM
+    set :foreman_sudo, 'rvmsudo'
 
 
 

--- a/lib/capistrano/foreman.rb
+++ b/lib/capistrano/foreman.rb
@@ -1,9 +1,11 @@
 Capistrano::Configuration.instance(:must_exist).load do |configuration|
 
+  _cset(:foreman_sudo, 'sudo')
+
   namespace :foreman do
     desc "Export the Procfile to Ubuntu's upstart scripts"
     task :export, roles: :app do
-      run "cd #{current_path} && sudo bundle exec foreman export upstart /etc/init -a sites/#{application} -u #{user} -l #{shared_path}/log #{concurrency}"
+      run "cd #{current_path} && #{foreman_sudo} bundle exec foreman export upstart /etc/init -a sites/#{application} -u #{user} -l #{shared_path}/log #{concurrency}"
     end
 
     desc "Start the application services"


### PR DESCRIPTION
For deployments with RVM sudo & bundle results in "command bundle not found"
