### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Capistrano tasks for foreman and upstart.
 Add this to your `Capfile`:
 
 ```ruby
-require 'foreman/capistrano'
+require 'capistrano/foreman'
 
 # Default settings
 set :foreman_sudo, 'sudo'                    # Set to `rvmsudo` if you're using RVM


### PR DESCRIPTION
We should use `require 'capistrano/foreman'`, right?
This wrong requiring really confuse me  and waste me about a hour, because foreman has the file 'foreman/capistrano' https://github.com/ddollar/foreman/blob/v0.63.0/lib/foreman/capistrano.rb 
