### PR TITLE
Binstubs support

### DIFF
--- a/lib/capistrano/foreman.rb
+++ b/lib/capistrano/foreman.rb
@@ -10,7 +10,7 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
     task :export, roles: :app do
       cmd = foreman_use_binstubs ? 'bin/foreman' : 'bundle exec foreman'
       run "if [[ -d #{foreman_upstart_path} ]]; then #{foreman_sudo} mkdir -p #{foreman_upstart_path}; fi"
-      run "cd #{current_path} && #{foreman_sudo} bundle exec foreman export upstart #{foreman_upstart_path} #{format options}"
+      run "cd #{current_path} && #{foreman_sudo} #{cmd} export upstart #{foreman_upstart_path} #{format(options)}"
     end
 
     desc "Start the application services"
@@ -27,18 +27,18 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
     task :restart, roles: :app do
       run "sudo service #{options[:app]} start || sudo service #{options[:app]}  restart"
     end
-  end
 
-  def options
-    {
-      app: application,
-      log: "#{shared_path}/log",
-      user: user
-    }.merge foreman_options
-  end
+    def options
+      {
+        app: application,
+        log: "#{shared_path}/log",
+        user: user
+      }.merge foreman_options
+    end
 
-  def format options
-    options.map { |opt, value| "--#{opt}=#{value}" }.join " "
+    def format opts
+      opts.map { |opt, value| "--#{opt}=#{value}" }.join " "
+    end
   end
   
 end


### PR DESCRIPTION
This adds a new configuration option to allow the use of bundler binstubs for foreman instead of bundle exec.

I also moved the `options` and `format` methods inside the foreman namespace since I was getting naming collisions with an existing Capistrano method named `format` 
