### PR TITLE
Pass role=1 as the concurrency argument for each role.

### DIFF
--- a/lib/capistrano-foreman.rb
+++ b/lib/capistrano-foreman.rb
@@ -1,3 +1,4 @@
+require 'capistrano/role'
 require "capistrano/version"
 
 module Capistrano

--- a/lib/capistrano/foreman.rb
+++ b/lib/capistrano/foreman.rb
@@ -7,24 +7,28 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
 
   namespace :foreman do
     desc "Export the Procfile to Ubuntu's upstart scripts"
-    task :export, roles: :app do
-      cmd = foreman_use_binstubs ? 'bin/foreman' : 'bundle exec foreman'
-      run "if [[ -d #{foreman_upstart_path} ]]; then #{foreman_sudo} mkdir -p #{foreman_upstart_path}; fi"
-      run "cd #{current_path} && #{foreman_sudo} #{cmd} export upstart #{foreman_upstart_path} #{format(options)}"
+    task :export do
+      find_servers_for_task(current_task).each do |host|
+        export_options = format({:concurrency => concurrency_from_roles(host)}.merge(options))
+
+        cmd = foreman_use_binstubs ? 'bin/foreman' : 'bundle exec foreman'
+        run "if [[ -d #{foreman_upstart_path} ]]; then #{foreman_sudo} mkdir -p #{foreman_upstart_path}; fi", :hosts => host
+        run "cd #{current_path} && #{foreman_sudo} #{cmd} export upstart #{foreman_upstart_path} #{export_options}", :hosts => host
+      end
     end
 
     desc "Start the application services"
-    task :start, roles: :app do
+    task :start do
       sudo "service #{options[:app]} start"
     end
 
     desc "Stop the application services"
-    task :stop, roles: :app do
+    task :stop do
       sudo "service #{options[:app]} stop"
     end
 
     desc "Restart the application services"
-    task :restart, roles: :app do
+    task :restart do
       run "sudo service #{options[:app]} start || sudo service #{options[:app]}  restart"
     end
 
@@ -36,9 +40,12 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
       }.merge foreman_options
     end
 
+    def concurrency_from_roles(host)
+      roles.map {|role_name, role| "#{role_name}=1" if role.include?(host) }.compact.join(',')
+    end
+
     def format opts
       opts.map { |opt, value| "--#{opt}=#{value}" }.join " "
     end
   end
-  
 end


### PR DESCRIPTION
This allows generation of upstart scripts for only the foreman processes for which a role is passed on each server.

The following example:

```
role :app, server1.example.com, server2.example.com
role :worker, server1.example.com
```

Will generate `-c app=1,worker=1` for server1 and `-c app=1` for server2.

I'm not certain this this is ready for inclusion in the main repo but figured I'd post it up here to get your thoughts. For me this allows me to control which applications are just app servers and which also run workers etc. It's also a little bit backwards incompatible but I think a solution could be found for that.
