### PR TITLE
Use release_path instead of current_path

### DIFF
--- a/lib/capistrano/foreman.rb
+++ b/lib/capistrano/foreman.rb
@@ -10,7 +10,7 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
     task :export, roles: :app do
       cmd = foreman_use_binstubs ? 'bin/foreman' : 'bundle exec foreman'
       run "if [[ -d #{foreman_upstart_path} ]]; then #{foreman_sudo} mkdir -p #{foreman_upstart_path}; fi"
-      run "cd #{current_path} && #{foreman_sudo} #{cmd} export upstart #{foreman_upstart_path} #{format(options)}"
+      run "cd #{release_path} && #{foreman_sudo} #{cmd} export upstart #{foreman_upstart_path} #{format(options)}"
     end
 
     desc "Start the application services"


### PR DESCRIPTION
If foreman was not installed in the last release (referenced by `current_path` in a deploy) a new release will fail to export the config. This uses the path of the version that is currently being released.
