### PR TITLE
Added alternative setup and rails enviroment options

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ Manage sites/app from shell as root or allowed sudoer:
 (sudo) restart sites/app
 ```
 
+## Environment management
+
+Foreman gem [handles environment variables](http://ddollar.github.io/foreman/#ENVIRONMENT) using .env files. It will load by default a file 
+ named`.env` if such file exist. If you want more fine grained control on the environment of exported configuration you can use these two variables:
+
+* `foreman_env_files`: (default `[]`) an explicit list of env files to load during export. It can be useful to load different env files in 
+  different capistrano env. With multistage extension one can do `set foreman_env_files, ['common', rails_env]`. The argument is 
+  an array of filenames *without* `.env` extension (it will be added automatically). If this list is not empty default `.env` file *won't*
+  be loaded by foreman.
+* `foreman_generate_rails_env`: (default `false`) if `true` a file with common Rails env variables (currently `RAILS_ENV` and `RACK_ENV`)
+ is automatically generated and prepended to the above list. Notice that setting this option to `true` will disable loading of default `.env`
+ file.
+
 ## Credits
 
 Hyper made this. We're a digital communications agency with a passion for good code,

--- a/lib/capistrano/foreman.rb
+++ b/lib/capistrano/foreman.rb
@@ -28,6 +28,11 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
       sudo "stop #{service_name}"
     end
 
+    desc "Reload the application services"
+    task :stop, roles: :app do
+      sudo "reload #{service_name}"
+    end
+
     desc "Restart the application services"
     task :restart, roles: :app do
       begin

--- a/lib/capistrano/foreman.rb
+++ b/lib/capistrano/foreman.rb
@@ -1,7 +1,7 @@
 Capistrano::Configuration.instance(:must_exist).load do |configuration|
 
-  _cset :foreman_sudo, "sudo"
-  _cset :foreman_upstart_path, "/etc/init/sites"
+  _cset :foreman_sudo, ""
+  _cset :foreman_upstart_path, "/etc/init/"
   _cset :foreman_options, {}
   _cset :foreman_use_binstubs, false
 
@@ -36,22 +36,14 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
 
     def options
       {
-        app: application,
+        app: "sites/#{application}",
         log: "#{shared_path}/log",
         user: user
       }.merge foreman_options
     end
     
     def service_name
-      # /etc/init/app.conf => start/stop/reload app
-      # /etc/init/sites/app.conf => start/stop/reload sites/app
-      # /other/path/ => ???
-      if foreman_upstart_path.start_with? "/etc/init" 
-        foreman_upstart_path =~ %r{^/etc/init/?$} ? application : "#{foreman_upstart_path.gsub(%{/etc/init/}, '')}/#{application}"
-      else
-        # ??? when upstart jobs are exported outside /etc/init what is the behavior?
-        application
-      end
+      options[:app]
     end
 
     def format opts

--- a/lib/capistrano/foreman.rb
+++ b/lib/capistrano/foreman.rb
@@ -4,8 +4,8 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
   _cset :foreman_upstart_path, "/etc/init/"
   _cset :foreman_options, {}
   _cset :foreman_use_binstubs, false
-  _cset :forman_base_port, 5000
-  _cset :forman_procfile, 'Procfile'
+  _cset :foreman_base_port, 5000
+  _cset :foreman_procfile, 'Procfile'
   _cset :foreman_env_files, []
   _cset :foreman_generate_rails_env, false
 
@@ -15,7 +15,7 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
       generate_rails_env if generate_rails_env?
       cmd = foreman_use_binstubs ? 'bin/foreman' : 'bundle exec foreman'
       run "if [[ -d #{foreman_upstart_path} ]]; then #{foreman_sudo} mkdir -p #{foreman_upstart_path}; fi"
-      run "cd #{current_path} && #{foreman_sudo} #{cmd} export -f #{forman_procfile} -p #{foreman_base_port} upstart #{foreman_upstart_path} #{format(options)}"
+      run "cd #{current_path} && #{foreman_sudo} #{cmd} export -f #{foreman_procfile} -p #{foreman_base_port} upstart #{foreman_upstart_path} #{format(options)}"
     end
     
     desc "Start the application services"

--- a/lib/capistrano/foreman.rb
+++ b/lib/capistrano/foreman.rb
@@ -4,15 +4,18 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
   _cset :foreman_upstart_path, "/etc/init/"
   _cset :foreman_options, {}
   _cset :foreman_use_binstubs, false
+  _cset :foreman_env_files, []
+  _cset :foreman_generate_rails_env, false
 
   namespace :foreman do
     desc "Export the Procfile to Ubuntu's upstart scripts"
     task :export, roles: :app do
+      generate_rails_env if generate_rails_env?
       cmd = foreman_use_binstubs ? 'bin/foreman' : 'bundle exec foreman'
       run "if [[ -d #{foreman_upstart_path} ]]; then #{foreman_sudo} mkdir -p #{foreman_upstart_path}; fi"
       run "cd #{current_path} && #{foreman_sudo} #{cmd} export upstart #{foreman_upstart_path} #{format(options)}"
     end
-
+    
     desc "Start the application services"
     task :start, roles: :app do
       sudo "start #{service_name}"
@@ -35,11 +38,7 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
     end
 
     def options
-      {
-        app: "sites/#{application}",
-        log: "#{shared_path}/log",
-        user: user
-      }.merge foreman_options
+      default_options.merge foreman_options
     end
     
     def service_name
@@ -49,6 +48,34 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
     def format opts
       opts.map { |opt, value| "--#{opt}=#{value}" }.join " "
     end
+    
+    def default_options
+      opts = {
+        app: "sites/#{application}",
+        log: "#{shared_path}/log",
+        user: user
+      }
+      # Add environments option if any file is given using options
+      opts[:env] = foreman_env_files.map { |env_file| "#{env_file}.env" }.join(',') unless foreman_env_files.empty?
+      opts
+    end
+    
+    # Write a rails.env file with common env entries for rails applications
+    def generate_rails_env
+      default_env = {
+        'RAILS_ENV' => rails_env,
+        'RACK_ENV' => rails_env,
+      }
+      # Write default environment to the server
+      put default_env.map { |k,v| "#{k}=#{v}" }.join("\n"), "#{current_path}/rails.env"
+      # Add generated file to file list used for export
+      foreman_env_files.unshift('rails')
+    end
+    
+    def generate_rails_env?
+      foreman_generate_rails_env
+    end
+    
   end
   
 end

--- a/lib/capistrano/foreman.rb
+++ b/lib/capistrano/foreman.rb
@@ -15,17 +15,17 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
 
     desc "Start the application services"
     task :start, roles: :app do
-      sudo "service #{options[:app]} start"
+      sudo "start #{service_name}"
     end
 
     desc "Stop the application services"
     task :stop, roles: :app do
-      sudo "service #{options[:app]} stop"
+      sudo "stop #{service_name}"
     end
 
     desc "Restart the application services"
     task :restart, roles: :app do
-      run "sudo service #{options[:app]} start || sudo service #{options[:app]}  restart"
+      sudo "restart #{service_name}"
     end
 
     def options

--- a/lib/capistrano/foreman.rb
+++ b/lib/capistrano/foreman.rb
@@ -35,6 +35,18 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
         user: user
       }.merge foreman_options
     end
+    
+    def service_name
+      # /etc/init/app.conf => start/stop/reload app
+      # /etc/init/sites/app.conf => start/stop/reload sites/app
+      # /other/path/ => ???
+      if foreman_upstart_path.start_with? "/etc/init" 
+        foreman_upstart_path =~ %r{^/etc/init/?$} ? application : "#{foreman_upstart_path.gsub(%{/etc/init/}, '')}/#{application}"
+      else
+        # ??? when upstart jobs are exported outside /etc/init what is the behavior?
+        application
+      end
+    end
 
     def format opts
       opts.map { |opt, value| "--#{opt}=#{value}" }.join " "

--- a/lib/capistrano/foreman.rb
+++ b/lib/capistrano/foreman.rb
@@ -4,6 +4,7 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
   _cset :foreman_upstart_path, "/etc/init/"
   _cset :foreman_options, {}
   _cset :foreman_use_binstubs, false
+  _cset :forman_base_port, 5000
   _cset :foreman_env_files, []
   _cset :foreman_generate_rails_env, false
 
@@ -13,7 +14,7 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
       generate_rails_env if generate_rails_env?
       cmd = foreman_use_binstubs ? 'bin/foreman' : 'bundle exec foreman'
       run "if [[ -d #{foreman_upstart_path} ]]; then #{foreman_sudo} mkdir -p #{foreman_upstart_path}; fi"
-      run "cd #{current_path} && #{foreman_sudo} #{cmd} export upstart #{foreman_upstart_path} #{format(options)}"
+      run "cd #{current_path} && #{foreman_sudo} #{cmd} export -p #{foreman_base_port} upstart #{foreman_upstart_path} #{format(options)}"
     end
     
     desc "Start the application services"

--- a/lib/capistrano/foreman.rb
+++ b/lib/capistrano/foreman.rb
@@ -5,6 +5,7 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
   _cset :foreman_options, {}
   _cset :foreman_use_binstubs, false
   _cset :forman_base_port, 5000
+  _cset :forman_procfile, 'Procfile'
   _cset :foreman_env_files, []
   _cset :foreman_generate_rails_env, false
 
@@ -14,7 +15,7 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
       generate_rails_env if generate_rails_env?
       cmd = foreman_use_binstubs ? 'bin/foreman' : 'bundle exec foreman'
       run "if [[ -d #{foreman_upstart_path} ]]; then #{foreman_sudo} mkdir -p #{foreman_upstart_path}; fi"
-      run "cd #{current_path} && #{foreman_sudo} #{cmd} export -p #{foreman_base_port} upstart #{foreman_upstart_path} #{format(options)}"
+      run "cd #{current_path} && #{foreman_sudo} #{cmd} export -f #{forman_procfile} -p #{foreman_base_port} upstart #{foreman_upstart_path} #{format(options)}"
     end
     
     desc "Start the application services"

--- a/lib/capistrano/foreman.rb
+++ b/lib/capistrano/foreman.rb
@@ -25,7 +25,13 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
 
     desc "Restart the application services"
     task :restart, roles: :app do
-      sudo "restart #{service_name}"
+      begin
+        logger.info "Try to restart service #{service_name}"
+        sudo "restart #{service_name}"
+      rescue
+        logger.info "Try to start service #{service_name} since it's not started yet"
+        sudo "start #{service_name}"
+      end
     end
 
     def options


### PR DESCRIPTION
I've encountered some issues with your current setup especially while running `rvmsudo` commands.

So I've created a fork which allows to run this gem using a deployment user with limited sudo privileges. In my setup I created the `sites` folder under `/etc/init/`  and i gave that user write privileges for that folder. In this way the `foreman export` command can be executed without sudo.

After this I gave deployer user sudo privileges to execute upstart commands with no password but only with `sites/*` argument. In this way you can obtain a full passwordless deployment with no need of `rvmsudo`

Most part of this is in the readme, but some changes are required in the [lib code to some default values](https://github.com/fabn/capistrano-foreman/commit/455a1e283f573288b20e9dcab2ef2eb625f714c1#L1R0)

In the last part of my PR I've added some rails specific options in order to automatically create a `rails.env` file with common rails variables (such as `RAILS_ENV`), in this way if you don't need any env customization you can run plain foreman commands in multiple environments (I'm using this with capistrano multistage support). For instance with unicorn apps you can have a `Procfile` with this content 
```
web:  bundle exec unicorn -c ./config/unicorn.rb
``` 
the same file can be used with no need to manage env files because automatically generated file will provide the right values in both production and staging env file.

Default behavior is the same as before since new options are empty by default.

I've documented these behaviours in the readme file you can read it on [my fork page](https://github.com/fabn/capistrano-foreman#rails-usage)

If you want to accept only part of this PR let me know and I'll try to rearrange.