### PR TITLE
Add Capistrano v3 support to the gem.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Copyright (c) 2012 Johannes Gorset
-Copyright (c) 2013 John Bellone
+Copyright (c) 2013-2014 John Bellone
 
 MIT License
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ Add this to your `Capfile`:
 require 'capistrano/foreman'
 
 # Default settings
-set :foreman_sudo, true
-set :foreman_export_path, '/etc/init/sites' # Set to `/etc/init/` if you don't have a sites folder
+set :foreman_use_sudo, false
+set :foreman_roles, :all
+set :foreman_template, 'upstart'
+set :foreman_export_path, File.join(Dir.home, '.init')
 set :foreman_options, {
   app: application,
-  log: "#{shared_path}/log",
-  user: user,
+  log: File.join(shared_path, 'log')
 }
 ```
 

--- a/capistrano-foreman.gemspec
+++ b/capistrano-foreman.gemspec
@@ -1,9 +1,8 @@
-# -*- encoding: utf-8 -*-
-require File.expand_path('../lib/capistrano/version', __FILE__)
+require File.expand_path('../lib/capistrano-foreman', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Johannes Gorset", "John Bellone"]
-  gem.email         = ["jgorset@gmail.com", "john.bellone.jr@gmail.com"]
+  gem.authors       = ["Johannes Gorset", 'John Bellone']
+  gem.email         = ["jgorset@gmail.com", 'jbellone@bloomberg.net']
   gem.description   = "Capistrano tasks for foreman and upstart."
   gem.summary       = "Capistrano tasks for foreman and upstart."
   gem.homepage      = "http://github.com/hyperoslo/capistrano-foreman"
@@ -14,4 +13,7 @@ Gem::Specification.new do |gem|
   gem.name          = "capistrano-foreman"
   gem.require_paths = ["lib"]
   gem.version       = Capistrano::Foreman::VERSION
+
+  gem.add_dependency 'capistrano', '~> 3.1'
+  gem.add_dependency 'capistrano-bundler', '~> 1.1'
 end

--- a/lib/capistrano-foreman.rb
+++ b/lib/capistrano-foreman.rb
@@ -2,5 +2,6 @@ require "capistrano/version"
 
 module Capistrano
   module Foreman
+    VERSION = "3.0.0"
   end
 end

--- a/lib/capistrano/foreman.rb
+++ b/lib/capistrano/foreman.rb
@@ -1,1 +1,1 @@
-load File.expand_path('../tasks/foreman.rake', __FILE__)
+load File.expand_path('../tasks/foreman.rb', __FILE__)

--- a/lib/capistrano/version.rb
+++ b/lib/capistrano/version.rb
@@ -1,5 +1,0 @@
-module Capistrano
-  module Foreman
-    VERSION = "2.0.0"
-  end
-end


### PR DESCRIPTION
These commits add support for the latest Capistrano changes. I have bumped the version up a major version so that if necessary its still pretty easy to continue along supporting the old version of the gem. The major changes here also include allowing for there to be a different format other than the upstart scripts.

I am actively testing a project against this. If anyone else has time please weigh in. 
