### PR TITLE
add foreman_command option

### DIFF
--- a/lib/capistrano/foreman.rb
+++ b/lib/capistrano/foreman.rb
@@ -4,13 +4,13 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
   _cset :foreman_upstart_path, "/etc/init/sites"
   _cset :foreman_options, {}
   _cset :foreman_use_binstubs, false
+  _cset :foreman_command, defer { foreman_use_binstubs ? 'bin/foreman' : 'bundle exec foreman' }
 
   namespace :foreman do
     desc "Export the Procfile to Ubuntu's upstart scripts"
     task :export, roles: :app do
-      cmd = foreman_use_binstubs ? 'bin/foreman' : 'bundle exec foreman'
       run "if [[ ! -d #{foreman_upstart_path} ]]; then #{foreman_sudo} mkdir -p #{foreman_upstart_path}; fi"
-      run "cd #{release_path} && #{foreman_sudo} #{cmd} export upstart #{foreman_upstart_path} #{format(options)}"
+      run "cd #{release_path} && #{foreman_sudo} #{foreman_command} export upstart #{foreman_upstart_path} #{format(options)}"
     end
 
     desc "Start the application services"


### PR DESCRIPTION
this adds a `:foreman_command` option to allow for customization of the
command used to run foreman
