### PR TITLE
Fix usage with Bundler and cleanup version

### DIFF
--- a/capistrano-foreman.gemspec
+++ b/capistrano-foreman.gemspec
@@ -1,4 +1,6 @@
-require File.expand_path('../lib/capistrano-foreman', __FILE__)
+# -*- encoding: utf-8 -*-
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.authors       = ["Johannes Gorset", 'John Bellone']
@@ -12,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.name          = "capistrano-foreman"
   gem.require_paths = ["lib"]
-  gem.version       = Capistrano::Foreman::VERSION
+  gem.version       = '3.0.0'
 
   gem.add_dependency 'capistrano', '~> 3.1'
   gem.add_dependency 'capistrano-bundler', '~> 1.1'

--- a/lib/capistrano-foreman.rb
+++ b/lib/capistrano-foreman.rb
@@ -1,7 +1,0 @@
-require "capistrano/version"
-
-module Capistrano
-  module Foreman
-    VERSION = "3.0.0"
-  end
-end


### PR DESCRIPTION
This cleans up the version by just moving it to the gemspec like other Capistrano modules. It also fixes issue #23 where Bundler would fail if the Gemspec specified the module as a git repository. It would load the gemspec, requiring `lib/capistrano-foreman.rb`, which in turn required `capistrano/version` which would fail (because Capistrano was not yet installed).

Both `Capistrano::Foreman::VERSION` and `capistrano/version` don't appear to be used anywhere else. I've blanked out the `lib/capistrano-foreman.rb` like other modules so that it just exists for Bundler auto-require to work.

Also, I left the version at what was previously set. But it seems like this should be 1.0.1 or at most 1.1.0. Not sure why it was bumped to 3.0.0. :confused: 
