### PR TITLE
Fixes  "Undefined method to_sym when deploying" #22 

### DIFF
--- a/lib/capistrano/tasks/foreman.rb
+++ b/lib/capistrano/tasks/foreman.rb
@@ -45,7 +45,7 @@ end
 
 namespace :load do
   task :defaults do
-    set :bundle_bins, fetch(:bundle_bins, []).push(%w(foreman))
+    set :bundle_bins, fetch(:bundle_bins, []).push('foreman')
     set :foreman_template, 'upstart'
     set :foreman_export_path, '/etc/init/sites'
     set :foreman_roles, :all


### PR DESCRIPTION
Originally fixed in https://github.com/jmcomets/capistrano-foreman, but
that repo is outdated
