### PR TITLE
Adds capistrano/rvm support

### DIFF
--- a/lib/capistrano/tasks/foreman.rb
+++ b/lib/capistrano/tasks/foreman.rb
@@ -50,5 +50,9 @@ namespace :load do
     set :foreman_export_path, '/etc/init/sites'
     set :foreman_roles, :all
     set :foreman_app, -> { fetch(:application) }
+
+    if !fetch(:rvm_map_bins).nil?
+      set :rvm_map_bins, fetch(:rvm_map_bins).push('foreman')
+    end
   end
 end


### PR DESCRIPTION
`foreman:export` fails because foreman is not included in the `rvm_map_bins` array (much like the `bundle_bins` one). This adds a fix for it to ensure foreman will always load throught the rvm bin

PS: This is commited on top of my previous pull request (https://github.com/hyperoslo/capistrano-foreman/pull/26), so if for some reason that one is not accepted, jsut let me know and i'll revert the changes so it doesn't affect this one
