### PR TITLE
Sudo is now optional

### DIFF
--- a/lib/capistrano/tasks/foreman.rb
+++ b/lib/capistrano/tasks/foreman.rb
@@ -13,7 +13,7 @@ namespace :foreman do
           log: File.join(shared_path, 'log'),
         }.merge fetch(:foreman_options, {})
 
-        execute :foreman, 'export',
+        foreman_exec :foreman, 'export',
           fetch(:foreman_template),
           fetch(:foreman_export_path),
           opts.map { |opt, value| "--#{opt}='#{value}'" }.join(' ')
@@ -24,21 +24,29 @@ namespace :foreman do
   desc 'Start the application services'
   task :start do
     on roles fetch(:foreman_roles) do
-      sudo :start, fetch(:foreman_app)
+      foreman_exec :start, fetch(:foreman_app)
     end
   end
 
   desc 'Stop the application services'
   task :stop do
     on roles fetch(:foreman_roles) do
-      sudo :stop, fetch(:foreman_app)
+      foreman_exec :stop, fetch(:foreman_app)
     end
   end
 
   desc 'Restart the application services'
   task :restart do
     on roles fetch(:foreman_roles) do
-      sudo :restart, fetch(:foreman_app)
+      foreman_exec :restart, fetch(:foreman_app)
+    end
+  end
+
+  def foreman_exec(*args)
+    if fetch(:foreman_use_sudo)
+      sudo(*args)
+    else
+      execute(*args)
     end
   end
 end
@@ -46,6 +54,7 @@ end
 namespace :load do
   task :defaults do
     set :bundle_bins, fetch(:bundle_bins, []).push('foreman')
+    set :foreman_use_sudo, false
     set :foreman_template, 'upstart'
     set :foreman_export_path, '/etc/init/sites'
     set :foreman_roles, :all


### PR DESCRIPTION
The README mentioned a `foreman_use_sudo` option, but that wasn't being used anywhere.
Additionally, `export` was not calling sudo, while `start|stop|restart` were always calling it, which made no sense

This patch adds the functionality for that flag