### PR TITLE
Allow you to run 'rbenv sudo' or 'rvmsudo' as well as 'sudo'

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this to your `Capfile`:
 require 'capistrano/foreman'
 
 # Default settings
-set :foreman_use_sudo, false
+set :foreman_use_sudo, false # Set to :rbenv for rbenv sudo, :rvm for rvmsudo or true for normal sudo
 set :foreman_roles, :all
 set :foreman_template, 'upstart'
 set :foreman_export_path, File.join(Dir.home, '.init')

--- a/lib/capistrano/tasks/foreman.rb
+++ b/lib/capistrano/tasks/foreman.rb
@@ -43,8 +43,14 @@ namespace :foreman do
   end
 
   def foreman_exec(*args)
-    if fetch(:foreman_use_sudo)
-      sudo(*args)
+    if sudo_type = fetch(:foreman_use_sudo)
+      if sudo_type.to_s == "rbenv"
+        execute(:rbenv, :sudo, *args)
+      elsif sudo_type.to_s == "rvm"
+        execute(:rvmsudo *args)
+      else
+        sudo(*args)
+      end
     else
       execute(*args)
     end


### PR DESCRIPTION
This allows you to run `rbenv sudo` or `rvmsudo` to export your foreman config to upstart therefore using the foreman specified in your Gemfile as opposed to having to install foreman as part of system ruby. 