### PR TITLE
Allow args to be interpolated

### DIFF
--- a/lib/capistrano/tasks/foreman.rb
+++ b/lib/capistrano/tasks/foreman.rb
@@ -16,7 +16,7 @@ namespace :foreman do
         foreman_exec :foreman, 'export',
           fetch(:foreman_template),
           fetch(:foreman_export_path),
-          opts.map { |opt, value| "--#{opt}='#{value}'" }.join(' ')
+          opts.map { |opt, value| "--#{opt}=\"#{value}\"" }.join(' ')
       end
     end
   end


### PR DESCRIPTION
I'm using it like this:

```ruby
set(
  :foreman_options,
  {
    :template => "`RBENV_ROOT=#{fetch(:rbenv_path)} RBENV_VERSION=#{fetch(:rbenv_ruby)} #{fetch(:rbenv_path)}/bin/rbenv exec bundle show foreman-upstart-su`/data/export/upstartsu"
  }
)
```