### PR TITLE
make the log directory before running foreman export

### DIFF
--- a/lib/capistrano/tasks/foreman.rb
+++ b/lib/capistrano/tasks/foreman.rb
@@ -7,12 +7,14 @@ namespace :foreman do
   desc 'Export the Procfile'
   task :export do
     on roles fetch(:foreman_roles) do
-      within release_path do
-        opts = {
-          app: fetch(:application),
-          log: File.join(shared_path, 'log'),
-        }.merge fetch(:foreman_options, {})
+      opts = {
+        app: fetch(:application),
+        log: File.join(shared_path, 'log'),
+      }.merge fetch(:foreman_options, {})
 
+      execute(:mkdir, "-p", opts[:log])
+
+      within release_path do
         foreman_exec :foreman, 'export',
           fetch(:foreman_template),
           fetch(:foreman_export_path),


### PR DESCRIPTION
Before this change upstart fails to start the process with `No such file or directory` if the log directory does not exist

