### PR TITLE
undefined method `to_sym' for ["foreman"]:Array fix

### DIFF
--- a/lib/capistrano/tasks/foreman.rb
+++ b/lib/capistrano/tasks/foreman.rb
@@ -59,7 +59,7 @@ end
 
 namespace :load do
   task :defaults do
-    set :bundle_bins, fetch(:bundle_bins, []).push('foreman')
+    set :bundle_bins, fetch(:bundle_bins, []).push(:foreman)
     set :foreman_use_sudo, false
     set :foreman_template, 'upstart'
     set :foreman_export_path, '/etc/init/sites'


### PR DESCRIPTION
Symbol instead of string to fix undefined method `to_sym' for ["foreman"]:Array error.