### PR TITLE
Manually modify 'rbenv sudo foreman' commands with 'rbenv sudo bundle ee...

### DIFF
--- a/lib/capistrano/tasks/foreman.rb
+++ b/lib/capistrano/tasks/foreman.rb
@@ -48,6 +48,9 @@ namespace :foreman do
     sudo_type = fetch(:foreman_use_sudo)
     case sudo_type.to_s
     when 'rbenv'
+      # this is required because 'rbenv sudo'
+      # is not recognized by bundle_bins
+      args.unshift(:bundle, :exec) if args[0].to_s == "foreman"
       execute(:rbenv, :sudo, *args)
     when 'rvm'
       execute(:rvmsudo, *args)


### PR DESCRIPTION
`rbenv sudo` is not recognized by `bundle_bins` so all `rbenv sudo foreman` commands need to be `rbenv sudo bundle exec foreman`