### PR TITLE
Use block syntax for :set

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ require 'capistrano/foreman'
 set :foreman_use_sudo, false # Set to :rbenv for rbenv sudo, :rvm for rvmsudo or true for normal sudo
 set :foreman_roles, :all
 set :foreman_template, 'upstart'
-set :foreman_export_path, File.join(Dir.home, '.init')
-set :foreman_options, {
+set :foreman_export_path, ->{ File.join(Dir.home, '.init') }
+set :foreman_options, ->{ {
   app: application,
   log: File.join(shared_path, 'log')
-}
+} }
 ```
 
 See [exporting options](http://ddollar.github.io/foreman/#EXPORTING0) for an exhaustive list of foreman options.


### PR DESCRIPTION
If you don't use the block syntax for `:set`, the listed variable are evaluated in the current context, rather than in the context in which foreman is run - ex. this way you can have the foreman defaults set in one place but have different settings for `shared_path` based on the environment.