### PR TITLE
allow setting foreman options in the server properties

### DIFF
--- a/lib/capistrano/tasks/foreman.rb
+++ b/lib/capistrano/tasks/foreman.rb
@@ -11,6 +11,8 @@ namespace :foreman do
         app: fetch(:application),
         log: File.join(shared_path, 'log'),
       }.merge fetch(:foreman_options, {})
+      
+      opts.merge!(host.properties.fetch(:foreman_options) || {})
 
       execute(:mkdir, "-p", opts[:log])
 


### PR DESCRIPTION
This will allow different options (like concurrency) per server.