### PR TITLE
Add systemd app name to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ set :foreman_use_sudo, false # Set to :rbenv for rbenv sudo, :rvm for rvmsudo or
 set :foreman_roles, :all
 set :foreman_init_system, 'upstart'
 set :foreman_export_path, ->{ File.join(Dir.home, '.init') }
+set :foreman_app, -> { fetch(:application) }
+set :foreman_app_name_systemd, -> { "#{ fetch(:foreman_app) }.target" }
 set :foreman_options, ->{ {
   app: application,
   log: File.join(shared_path, 'log')


### PR DESCRIPTION
Was trying half an hour to fix a problem with an application name which uses a dot in it's name and didn't work - until I found out I can easily use the `foreman_app` key... Would be nice to document this, so I created this pull request.