### PR TITLE
Bump dependency on capistrano-bundler to ~> 2.0

### DIFF
--- a/capistrano-foreman.gemspec
+++ b/capistrano-foreman.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.version       = '1.4.0'
 
   gem.add_dependency 'capistrano', '~> 3.1'
-  gem.add_dependency 'capistrano-bundler', '~> 1.1'
+  gem.add_dependency 'capistrano-bundler', '~> 2.0'
 end


### PR DESCRIPTION
2.0 was released almost 2 years ago: https://rubygems.org/gems/capistrano-bundler